### PR TITLE
Add docker compose runner with port monitoring

### DIFF
--- a/host-scripts/dc-run
+++ b/host-scripts/dc-run
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Run a docker compose project and monitor exposed web ports."""
+import argparse
+import subprocess
+import time
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import requests
+import yaml
+
+
+def detect_ports(compose_dir: str) -> List[int]:
+    """Detect host ports from a docker compose file."""
+    candidates = [
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        "compose.yml",
+        "compose.yaml",
+    ]
+    base = Path(compose_dir)
+    for name in candidates:
+        path = base / name
+        if path.exists():
+            with path.open() as fh:
+                data = yaml.safe_load(fh) or {}
+            ports: List[int] = []
+            services = data.get("services", {})
+            for service in services.values():
+                for entry in service.get("ports", []):
+                    host_port = None
+                    if isinstance(entry, str):
+                        # "HOST:CONTAINER" or "HOST:CONTAINER/PROTO"
+                        host = entry.split(":")[0]
+                        if host.isdigit():
+                            host_port = int(host)
+                    elif isinstance(entry, dict):
+                        host = entry.get("published") or entry.get("host")
+                        if isinstance(host, int) or (
+                            isinstance(host, str) and host.isdigit()
+                        ):
+                            host_port = int(host)
+                    if host_port:
+                        ports.append(host_port)
+            return sorted(set(ports))
+    return []
+
+
+def check_ports(ports: Iterable[int], status: Dict[int, bool]) -> None:
+    """Check ports and report when they change state."""
+    for port in ports:
+        url = f"http://localhost:{port}"
+        try:
+            response = requests.get(url, timeout=2)
+            if response.ok:
+                if status.get(port) is not True:
+                    print(f"Port {port} is up")
+                status[port] = True
+            else:
+                if status.get(port) is not False:
+                    print(f"Port {port} returned HTTP {response.status_code}")
+                status[port] = False
+        except Exception as exc:  # pylint: disable=broad-except
+            if status.get(port) is not False:
+                print(f"Port {port} check failed: {exc}")
+            status[port] = False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run docker compose up with simple port monitoring"
+    )
+    parser.add_argument(
+        "-C",
+        "--compose-dir",
+        default=".",
+        help="Directory containing docker-compose.yml",
+    )
+    parser.add_argument(
+        "-p",
+        "--ports",
+        nargs="*",
+        type=int,
+        help="Ports to monitor. If omitted, ports are detected from compose file.",
+    )
+    parser.add_argument(
+        "-i", "--interval", type=float, default=5.0, help="Seconds between checks"
+    )
+
+    args, compose_args = parser.parse_known_args()
+
+    ports = args.ports or detect_ports(args.compose_dir)
+    if ports:
+        print(f"Monitoring ports: {', '.join(str(p) for p in ports)}")
+    else:
+        print("No ports detected for monitoring")
+
+    cmd = ["docker", "compose", "up"] + compose_args
+    proc = subprocess.Popen(cmd, cwd=args.compose_dir)
+
+    status: Dict[int, bool] = {}
+    try:
+        while proc.poll() is None:
+            if ports:
+                check_ports(ports, status)
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        proc.terminate()
+    finally:
+        proc.wait()
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML
+requests


### PR DESCRIPTION
## Summary
- add `dc-run` script to run docker compose projects and monitor web ports
- list `PyYAML` and `requests` in requirements for port detection and HTTP checks

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 host-scripts/dc-run --help`


------
https://chatgpt.com/codex/tasks/task_e_689ddd480080832f9f0d1c9403348798